### PR TITLE
Docs: Continue comprehensive documentation for ScheduleOne

### DIFF
--- a/docs/Calling/PayPhone.md
+++ b/docs/Calling/PayPhone.md
@@ -1,0 +1,54 @@
+# PayPhone
+
+Inherits from `MonoBehaviour`.
+
+## Description
+
+This class controls the behavior of a payphone in the game world. It can ring to signal a `QueuedCall` from the `CallManager`, and the player can interact with it to answer the call.
+
+## Constants
+
+-   **RING_INTERVAL**: `float` - The time in seconds between rings (4 seconds).
+-   **RING_RANGE**: `float` - The maximum distance from the player at which the phone will ring (9 units).
+
+## Fields
+
+-   **Light**: `BlinkingLight`
+    -   A reference to a `BlinkingLight` component that will flash when a call is queued.
+-   **RingSound**: `AudioSourceController`
+    -   The audio source for the ringing sound effect.
+-   **AnswerSound**: `AudioSourceController`
+    -   The audio source for the sound effect when the phone is answered.
+-   **IntObj**: `InteractableObject`
+    -   The `InteractableObject` component for the payphone.
+-   **CameraPosition**: `Transform`
+    -   The position and rotation the player's camera should move to when answering the call.
+
+## Properties
+
+-   **QueuedCall**: `PhoneCallData` (read-only)
+    -   Gets the currently queued call from the `CallManager`.
+-   **ActiveCall**: `PhoneCallData` (read-only)
+    -   Gets the currently active call from the `CallInterface`.
+
+## Methods
+
+### FixedUpdate
+`public void FixedUpdate()`
+
+Periodically checks if there is a queued call and if the player is within range. If so, it makes the light blink and plays the `RingSound` at intervals.
+
+### Hovered
+`public void Hovered()`
+
+Called when the player's crosshair is over the payphone. It updates the interaction message on the `InteractableObject` to "Answer phone" if a call can be answered.
+
+### Interacted
+`public void Interacted()`
+
+Called when the player interacts with the payphone. If a call can be answered, it starts the call via the `CallInterface`, stops the ringing, plays the answer sound, and moves the player's camera to the `CameraPosition`.
+
+### CanInteract
+`private bool CanInteract()`
+
+Checks if the player is allowed to answer the phone. This is true if there is a queued call, no other call is active, and the call interface is not already open.

--- a/docs/Casino/BlackjackGameController.md
+++ b/docs/Casino/BlackjackGameController.md
@@ -1,0 +1,80 @@
+# BlackjackGameController
+
+Inherits from `CasinoGameController`.
+
+## Description
+
+This class manages the entire lifecycle and logic for a networked game of Blackjack. It handles player betting, dealing cards, player turns, the dealer's turn, and calculating payouts. It synchronizes the game state across all clients using FishNet networking.
+
+## Enums
+
+### EStage
+Describes the current stage of the game.
+-   `WaitingForPlayers`
+-   `Dealing`
+-   `PlayerTurn`
+-   `DealerTurn`
+-   `Ending`
+
+### EPayoutType
+Describes the result of a player's hand.
+-   `None`
+-   `Blackjack` (A score of 21 on the initial two cards)
+-   `Win` (Player's score is higher than the dealer's, without busting)
+-   `Push` (Player and dealer have the same score)
+
+## Key Properties
+
+-   **CurrentStage**: `EStage` (read-only) - The current stage of the game.
+-   **PlayerTurn**: `Player` (read-only) - The player whose turn it is currently.
+-   **LocalPlayerBet**: `float` - The bet amount for the local player.
+-   **DealerScore**: `int` (read-only) - The current score of the dealer's hand.
+-   **LocalPlayerScore**: `int` (read-only) - The current score of the local player's hand.
+-   **IsLocalPlayerInCurrentRound**: `bool` (read-only) - True if the local player is participating in the current round.
+
+## Game Flow
+
+The game operates as a state machine, progressing through the `EStage` enum values.
+
+1.  **WaitingForPlayers**: The game waits until all players at the table have marked themselves as "Ready".
+2.  **Dealing**: The server-side `GameRoutine` coroutine begins. It deals two cards to each player and two to the dealer (one face down).
+3.  **PlayerTurn**: The `GameRoutine` iterates through each player in clockwise order. It waits for the player to take an action (Hit or Stand).
+    -   If the player "Hits", they are dealt another card.
+    -   If they "Stand", their turn ends.
+    -   If their score exceeds 21, they "Bust" and are removed from the round.
+4.  **DealerTurn**: After all players have had their turn, the dealer reveals their face-down card. The dealer must hit until their score is 17 or higher.
+5.  **Ending**: Payouts are calculated for all remaining players based on their final score versus the dealer's score. The game then transitions back to `WaitingForPlayers`.
+
+## Public Methods
+
+### RemoveLocalPlayerFromGame
+`public void RemoveLocalPlayerFromGame(EPayoutType payout, float cameraDelay = 0f)`
+
+Removes the local player from the current round, calculates and applies their payout, and resets their camera view.
+
+-   **Parameters:**
+    -   `payout`: The `EPayoutType` determining the win/loss condition.
+    -   `cameraDelay`: A delay before the camera moves back to the default position.
+
+### GetPayout
+`public float GetPayout(float bet, EPayoutType payout)`
+
+Calculates the monetary payout based on the bet and the result of the hand.
+
+-   **Parameters:**
+    -   `bet`: The initial bet amount.
+    -   `payout`: The `EPayoutType` result.
+-   **Returns:** The amount of money the player should receive.
+
+### SetLocalPlayerBet
+`public void SetLocalPlayerBet(float bet)`
+
+Sets the bet amount for the local player for the next round.
+
+-   **Parameters:**
+    -   `bet`: The desired bet amount.
+
+### ToggleLocalPlayerReady
+`public void ToggleLocalPlayerReady()`
+
+Toggles the "Ready" state for the local player, used to start the game.

--- a/docs/Casino/PlayingCard.md
+++ b/docs/Casino/PlayingCard.md
@@ -1,0 +1,76 @@
+# PlayingCard
+
+Inherits from `MonoBehaviour`.
+
+## Description
+
+This class represents a single playing card. It manages the card's visual appearance (suit and value), its physical state in the world (position, rotation, face-up/face-down), and communicates changes to a `CardController` for network synchronization.
+
+## Inner Classes & Structs
+
+### CardSprite (Serializable Class)
+Links a suit and value to a specific `Sprite`.
+-   **Suit**: `ECardSuit`
+-   **Value**: `ECardValue`
+-   **Sprite**: `Sprite`
+
+### CardData (Struct)
+A simple data structure to hold the suit and value of a card.
+-   **Suit**: `ECardSuit`
+-   **Value**: `ECardValue`
+
+## Enums
+
+### ECardSuit
+`Spades`, `Hearts`, `Diamonds`, `Clubs`
+
+### ECardValue
+`Blank`, `Ace`, `Two`, `Three`, `Four`, `Five`, `Six`, `Seven`, `Eight`, `Nine`, `Ten`, `Jack`, `Queen`, `King`
+
+## Fields
+
+-   **CardID**: `string` - A unique identifier for this card instance (e.g., "card_1").
+-   **CardSpriteRenderer**: `SpriteRenderer` - The renderer that displays the card's face.
+-   **CardSprites**: `CardSprite[]` - An array mapping all possible suit/value combinations to their sprites.
+-   **FlipAnimation**: `Animation` - The `Animation` component used for flipping the card.
+-   **FlipSound**: `AudioSourceController` - The sound played when the card is flipped.
+-   **LandSound**: `AudioSourceController` - The sound played when the card lands after moving.
+
+## Properties
+
+-   **IsFaceUp**: `bool` (read-only) - Is the card currently face-up?
+-   **Suit**: `ECardSuit` (read-only) - The current suit of the card.
+-   **Value**: `ECardValue` (read-only) - The current value of the card.
+-   **CardController**: `CardController` (read-only) - A reference to the parent controller for networking.
+
+## Methods
+
+### SetCard
+`public void SetCard(ECardSuit suit, ECardValue value, bool network = true)`
+
+Sets the suit and value of the card, updating its sprite. If `network` is true, it sends this change to the `CardController` to be broadcast to other clients.
+
+-   **Parameters:**
+    -   `suit`: The new suit.
+    -   `value`: The new value.
+    -   `network`: Whether to synchronize this change over the network.
+
+### SetFaceUp
+`public void SetFaceUp(bool faceUp, bool network = true)`
+
+Sets the card to be face-up or face-down, playing a flipping animation and sound. If `network` is true, it synchronizes the state.
+
+-   **Parameters:**
+    -   `faceUp`: True to make the card face-up, false for face-down.
+    -   `network`: Whether to synchronize this change over the network.
+
+### GlideTo
+`public void GlideTo(Vector3 position, Quaternion rotation, float duration = 0.5f, bool network = true)`
+
+Moves the card smoothly to a target position and rotation over a given duration. The movement includes a slight arc. If `network` is true, it synchronizes the movement.
+
+-   **Parameters:**
+    -   `position`: The target world position.
+    -   `rotation`: The target world rotation.
+    -   `duration`: The time the movement should take.
+    -   `network`: Whether to synchronize this change over the network.

--- a/docs/Casino/RTBGameController.md
+++ b/docs/Casino/RTBGameController.md
@@ -1,0 +1,69 @@
+# RTBGameController
+
+Inherits from `CasinoGameController`. (RTB likely stands for "Ride the Bus").
+
+## Description
+
+This class manages the entire lifecycle and logic for a networked game of "Ride the Bus". It's a multi-stage card guessing game where players try to correctly predict the outcome of the next card drawn. Players who guess incorrectly are eliminated, while those who guess correctly advance to the next stage with a higher bet multiplier.
+
+## Enums
+
+### EStage
+Describes the current stage of the game.
+-   `WaitingForPlayers`
+-   `RedOrBlack` - Guess if the card is red or black.
+-   `HigherOrLower` - Guess if the card is higher or lower than the previous one.
+-   `InsideOrOutside` - Guess if the card's value is between or outside the values of the previous two cards.
+-   `Suit` - Guess the suit of the card.
+
+## Key Properties
+
+-   **CurrentStage**: `EStage` (read-only) - The current stage of the game.
+-   **IsQuestionActive**: `bool` (read-only) - Is the game currently waiting for player input?
+-   **LocalPlayerBet**: `float` - The initial bet amount for the local player.
+-   **LocalPlayerBetMultiplier**: `float` (read-only) - The current multiplier for the local player's bet.
+-   **MultipliedLocalPlayerBet**: `float` (read-only) - The potential winnings for the local player.
+-   **RemainingAnswerTime**: `float` (read-only) - Time left for the player to answer the current question.
+-   **IsLocalPlayerInCurrentRound**: `bool` (read-only) - True if the local player is still in the game.
+
+## Game Flow
+
+1.  **WaitingForPlayers**: The game waits for all players at the table to mark themselves as "Ready".
+2.  **RunRound**: When the game starts, it enters a `RunRound` coroutine for the first stage (`RedOrBlack`).
+3.  **Ask Question**: A card is placed face-down. A question and possible answers are presented to the players (e.g., "Red or Black?"). A timer begins.
+4.  **Reveal Answer**: After the timer ends or all players have answered, the card is flipped face-up.
+5.  **Notify Players**: The server notifies clients of the correct answer. Players who guessed correctly have their `LocalPlayerBetMultiplier` increased and advance to the next stage. Players who guessed incorrectly are eliminated.
+6.  **Advance Stage**: If there are still players in the round and the final stage (`Suit`) has not been reached, the game advances to the next stage and a new `RunRound` coroutine begins.
+7.  **End Game**: The game ends when all players have been eliminated or after the final `Suit` stage is complete. Any remaining players are paid out based on their final bet multiplier. The game then resets to the `WaitingForPlayers` stage.
+
+## Public Methods
+
+### RemoveLocalPlayerFromGame
+`public void RemoveLocalPlayerFromGame(bool payout, float cameraDelay = 0f)`
+
+Removes the local player from the current round. If `payout` is true, their bet multiplied by the final `LocalPlayerBetMultiplier` is added to their balance.
+
+-   **Parameters:**
+    -   `payout`: Whether the player should be paid out (i.e., they won) or not (they were eliminated).
+    -   `cameraDelay`: A delay before the camera moves back to the default position.
+
+### SetLocalPlayerBet
+`public void SetLocalPlayerBet(float bet)`
+
+Sets the initial bet amount for the local player for the next game.
+
+-   **Parameters:**
+    -   `bet`: The desired bet amount.
+
+### SetLocalPlayerAnswer
+`public void SetLocalPlayerAnswer(float answer)`
+
+Sets the local player's answer for the current question. The float corresponds to the button index (e.g., 1.0 for the first answer, 2.0 for the second).
+
+-   **Parameters:**
+    -   `answer`: The player's chosen answer.
+
+### ToggleLocalPlayerReady
+`public void ToggleLocalPlayerReady()`
+
+Toggles the "Ready" state for the local player, used to start the game.

--- a/docs/Casino/SlotMachine.md
+++ b/docs/Casino/SlotMachine.md
@@ -1,0 +1,64 @@
+# SlotMachine
+
+Inherits from `NetworkBehaviour`.
+
+## Description
+
+This class controls a networked slot machine. It handles player interactions for setting a bet and pulling the handle, communicates with the server to get a result, and plays the corresponding animations and sounds for the spin and the outcome.
+
+## Enums
+
+### ESymbol
+The symbols that can appear on the reels.
+-   `Cherry`, `Lemon`, `Grape`, `Watermelon`, `Bell`, `Seven`
+
+### EOutcome
+The possible win/loss outcomes of a spin.
+-   `Jackpot`, `BigWin`, `SmallWin`, `MiniWin`, `NoWin`
+
+## Fields
+
+-   **BetAmounts**: `static int[]` - An array of possible bet values (5, 10, 25, 50, 100).
+-   **DownButton/UpButton**: `InteractableObject` - Interaction objects for increasing/decreasing the bet.
+-   **HandleIntObj**: `InteractableObject` - The interaction object for the main handle.
+-   **BetAmountLabel**: `TextMeshPro` - The text display for the current bet amount.
+-   **Reels**: `SlotReel[]` - An array of the `SlotReel` components that make up the machine.
+-   **SpinLoop**: `AudioSourceController` - The looping sound played while the reels are spinning.
+-   **ScreenAnimation**: `Animation` - The animation component for the win/jackpot screen display.
+-   **JackpotParticles**: `ParticleSystem[]` - Particle effects for a jackpot win.
+-   **Win-related fields**: Various `AnimationClip` and `AudioSourceController` fields for different win levels.
+
+## Properties
+
+-   **IsSpinning**: `bool` (read-only) - True if the machine is currently in the middle of a spin.
+
+## Gameplay Flow
+
+1.  **Betting**: The player interacts with the `UpButton` and `DownButton` to cycle through the `BetAmounts`. This sends an RPC to the server to update the bet index.
+2.  **Spinning**: The player interacts with the `HandleIntObj`.
+    -   The client deducts the bet amount from their `MoneyManager`.
+    -   It sends a `SendStartSpin` RPC to the server, including the player's connection and bet amount.
+3.  **Server Logic**:
+    -   The server receives the `SendStartSpin` request.
+    -   It determines a random outcome (an array of `ESymbol`s, one for each reel).
+    -   It sends an `ObserversRpc` (`StartSpin`) back to all clients with the determined symbols.
+4.  **Client-Side Spin and Outcome**:
+    -   All clients receive the `StartSpin` RPC and begin the spin animation locally.
+    -   The `Spin` coroutine starts, spinning each reel in sequence.
+    -   After a delay, the reels stop on the symbols provided by the server.
+    -   The client evaluates the outcome based on the symbols (`EvaluateOutcome`).
+    -   The client calculates the win amount (`GetWinAmount`).
+    -   The client displays the appropriate win animation and sound (`DisplayOutcome`).
+    -   If the winning player is the local player, the win amount is added to their `MoneyManager`.
+
+## Public Methods
+
+### HandleInteracted
+`public void HandleInteracted()`
+
+Called when the player pulls the handle. It checks if a spin is possible, deducts the bet from the player's balance, and sends an RPC to the server to start the spin.
+
+### SetBetIndex
+`public void SetBetIndex(NetworkConnection conn, int index)`
+
+An RPC to set the current bet index, which determines the bet amount. This is synchronized across clients.

--- a/docs/Casino/SlotReel.md
+++ b/docs/Casino/SlotReel.md
@@ -1,0 +1,56 @@
+# SlotReel
+
+Inherits from `MonoBehaviour`.
+
+## Description
+
+This class controls a single reel of a `SlotMachine`. It handles the visual spinning of the reel and stopping it at a specific symbol.
+
+## Inner Classes
+
+### SymbolRotation (Serializable Class)
+A simple class to map a `SlotMachine.ESymbol` to a specific rotation value (in degrees).
+-   **Symbol**: `SlotMachine.ESymbol`
+-   **Rotation**: `float`
+
+## Fields
+
+-   **SymbolRotations**: `SymbolRotation[]` - An array that defines the target rotation for each possible symbol on the reel.
+-   **SpinSpeed**: `float` - The speed at which the reel rotates when spinning, in degrees per second.
+-   **StopSound**: `AudioSourceController` - The sound effect to play when the reel comes to a stop.
+-   **onStart**: `UnityEvent` - An event invoked when the reel starts spinning.
+-   **onStop**: `UnityEvent` - An event invoked when the reel stops.
+
+## Properties
+
+-   **IsSpinning**: `bool` (read-only) - True if the reel is currently spinning.
+-   **CurrentSymbol**: `SlotMachine.ESymbol` (read-only) - The symbol the reel is currently showing or will stop on.
+-   **CurrentRotation**: `float` (read-only) - The current local rotation of the reel around its X-axis.
+
+## Methods
+
+### Update
+`private void Update()`
+
+Continuously updates the reel's rotation. If `IsSpinning` is true, it increments the rotation by `SpinSpeed`. If false, it ensures the reel's rotation is set to the correct angle for the `CurrentSymbol`.
+
+### Spin
+`public void Spin()`
+
+Starts the spinning of the reel by setting `IsSpinning` to true and invoking the `onStart` event.
+
+### Stop
+`public void Stop(SlotMachine.ESymbol endSymbol)`
+
+Stops the reel at a specific symbol. It sets `IsSpinning` to false, updates the `CurrentSymbol`, plays the `StopSound`, and invokes the `onStop` event.
+
+-   **Parameters:**
+    -   `endSymbol`: The `SlotMachine.ESymbol` that the reel should display when it stops.
+
+### SetSymbol
+`public void SetSymbol(SlotMachine.ESymbol symbol)`
+
+Immediately sets the `CurrentSymbol` without affecting the spinning state.
+
+-   **Parameters:**
+    -   `symbol`: The symbol to set.

--- a/docs/Clothing/ClothingColorExtensions.md
+++ b/docs/Clothing/ClothingColorExtensions.md
@@ -1,0 +1,56 @@
+# ClothingColorExtensions
+
+A static class containing extension methods for the `EClothingColor` enum.
+
+## Description
+
+This class provides helper methods to convert an `EClothingColor` enum value into its corresponding `UnityEngine.Color` or string label. It relies on the `ClothingUtility` singleton to retrieve the color data.
+
+## Methods
+
+### GetActualColor
+`public static Color GetActualColor(this EClothingColor color)`
+
+Gets the actual `UnityEngine.Color` value used for rendering the clothing item.
+
+-   **Parameters:**
+    -   `color`: The `EClothingColor` enum value.
+-   **Returns:** The `Color` struct associated with the enum value.
+
+### GetLabelColor
+`public static Color GetLabelColor(this EClothingColor color)`
+
+Gets the `UnityEngine.Color` value used for displaying the color in UI labels.
+
+-   **Parameters:**
+    -   `color`: The `EClothingColor` enum value.
+-   **Returns:** The UI label `Color` associated with the enum value.
+
+### GetLabel
+`public static string GetLabel(this EClothingColor color)`
+
+Gets the string representation of the enum value.
+
+-   **Parameters:**
+    -   `color`: The `EClothingColor` enum value.
+-   **Returns:** The name of the enum value as a string (e.g., "White").
+
+### GetClothingColor
+`public static EClothingColor GetClothingColor(Color color)`
+
+Performs a reverse lookup, finding the `EClothingColor` enum value that most closely matches a given `UnityEngine.Color`.
+
+-   **Parameters:**
+    -   `color`: The `Color` to find a match for.
+-   **Returns:** The matching `EClothingColor`, or `EClothingColor.White` if no close match is found.
+
+### ColorEquals
+`public static bool ColorEquals(Color a, Color b, float tolerance = 0.004f)`
+
+Compares two `Color` structs to see if they are approximately equal within a given tolerance.
+
+-   **Parameters:**
+    -   `a`: The first color.
+    -   `b`: The second color.
+    -   `tolerance`: The maximum allowed difference for each color channel (r, g, b).
+-   **Returns:** `true` if the colors are within the tolerance, otherwise `false`.

--- a/docs/Clothing/ClothingDefinition.md
+++ b/docs/Clothing/ClothingDefinition.md
@@ -1,0 +1,33 @@
+# ClothingDefinition
+
+Inherits from `StorableItemDefinition`.
+
+## Description
+
+A `ScriptableObject` that defines a piece of clothing. It extends the `StorableItemDefinition` with properties specific to clothing, such as the slot it occupies, how it's applied to the avatar, and its color options.
+
+## Fields
+
+-   **Slot**: `EClothingSlot`
+    -   The primary slot this clothing item occupies (e.g., `Top`, `Bottom`, `Headwear`).
+-   **ApplicationType**: `EClothingApplicationType`
+    -   How the clothing is applied to the avatar, such as a body layer texture or an accessory model.
+-   **ClothingAssetPath**: `string`
+    -   The path to the clothing asset (e.g., the texture for a shirt or the prefab for a hat).
+-   **Colorable**: `bool`
+    -   Can this item be colored by the player?
+-   **DefaultColor**: `EClothingColor`
+    -   The default color of the item when it's created.
+-   **SlotsToBlock**: `List<EClothingSlot>`
+    -   A list of other clothing slots that this item will hide or block when equipped (e.g., a full-body outfit might block the `Top` and `Bottom` slots).
+
+## Methods
+
+### GetDefaultInstance
+`public override ItemInstance GetDefaultInstance(int quantity = 1)`
+
+Overrides the base method to create a `ClothingInstance` with the `DefaultColor` when a new instance of this item is needed.
+
+-   **Parameters:**
+    -   `quantity`: The quantity of the item (usually 1 for clothing).
+-   **Returns:** A new `ClothingInstance` based on this definition.

--- a/docs/Clothing/ClothingInstance.md
+++ b/docs/Clothing/ClothingInstance.md
@@ -1,0 +1,48 @@
+# ClothingInstance
+
+Inherits from `StorableItemInstance`.
+
+## Description
+
+This class represents a specific instance of a piece of clothing. It extends `StorableItemInstance` to include a `Color` property, allowing each piece of clothing to have a specific color assigned to it.
+
+## Fields
+
+-   **Color**: `EClothingColor`
+    -   The color of this specific clothing instance.
+
+## Properties
+
+-   **Name**: `string` (override)
+    -   Overrides the base `Name` property to append the color's label in parentheses if the color is not white (e.g., "T-Shirt (Red)").
+
+## Constructors
+
+### ClothingInstance()
+An empty constructor, likely for serialization purposes.
+
+### ClothingInstance(ItemDefinition definition, int quantity, EClothingColor color)
+Creates a new instance of a clothing item.
+
+-   **Parameters:**
+    -   `definition`: The `ClothingDefinition` of the item.
+    -   `quantity`: The quantity of the item.
+    -   `color`: The `EClothingColor` for this instance.
+
+## Methods
+
+### GetCopy
+`public override ItemInstance GetCopy(int overrideQuantity = -1)`
+
+Creates a new `ClothingInstance` that is a copy of this one.
+
+-   **Parameters:**
+    -   `overrideQuantity`: If provided, the new copy will have this quantity. Otherwise, it uses the current instance's quantity.
+-   **Returns:** A new `ClothingInstance` with the same properties.
+
+### GetItemData
+`public override ItemData GetItemData()`
+
+Creates a `ClothingData` object for serialization, capturing the item's ID, quantity, and color. This is used for saving the game state.
+
+-   **Returns:** A `ClothingData` object containing this instance's data.

--- a/docs/Clothing/ClothingUtility.md
+++ b/docs/Clothing/ClothingUtility.md
@@ -1,0 +1,53 @@
+# ClothingUtility
+
+Inherits from `Singleton<ClothingUtility>`.
+
+## Description
+
+A singleton utility class that serves as a central database for clothing-related data. It holds lists that map `EClothingColor` and `EClothingSlot` enums to more detailed data, such as `UnityEngine.Color` values, names, and icons.
+
+## Inner Classes
+
+### ColorData (Serializable Class)
+Maps an `EClothingColor` enum to its render color and a separate color for UI labels.
+-   **ColorType**: `EClothingColor` - The enum key.
+-   **ActualColor**: `Color` - The color used for rendering the item.
+-   **LabelColor**: `Color` - The color used for UI text.
+
+### ClothingSlotData (Serializable Class)
+Maps an `EClothingSlot` enum to its display name and UI icon.
+-   **Slot**: `EClothingSlot` - The enum key.
+-   **Name**: `string` - The display name for the slot.
+-   **Icon**: `Sprite` - The UI icon for the slot.
+
+## Fields
+
+-   **ColorDataList**: `List<ColorData>`
+    -   The master list of all color data, editable in the Inspector.
+-   **ClothingSlotDataList**: `List<ClothingSlotData>`
+    -   The master list of all clothing slot data, editable in the Inspector.
+
+## Methods
+
+### OnValidate
+`private void OnValidate()`
+
+A Unity editor-only method that runs when the script is loaded or a value is changed in the Inspector. It automatically populates the `ColorDataList` and `ClothingSlotDataList` with default entries for any enum values that are missing, preventing data gaps.
+
+### GetColorData
+`public ColorData GetColorData(EClothingColor color)`
+
+Retrieves the `ColorData` object for a given `EClothingColor`.
+
+-   **Parameters:**
+    -   `color`: The `EClothingColor` to look up.
+-   **Returns:** The corresponding `ColorData` object, or `null` if not found.
+
+### GetSlotData
+`public ClothingSlotData GetSlotData(EClothingSlot slot)`
+
+Retrieves the `ClothingSlotData` object for a given `EClothingSlot`.
+
+-   **Parameters:**
+    -   `slot`: The `EClothingSlot` to look up.
+-   **Returns:** The corresponding `ClothingSlotData` object, or `null` if not found.

--- a/docs/Clothing/EClothingApplicationType.md
+++ b/docs/Clothing/EClothingApplicationType.md
@@ -1,0 +1,9 @@
+# EClothingApplicationType
+
+An enum that defines how a piece of clothing is applied to an avatar.
+
+## Values
+
+-   **BodyLayer**: The clothing is applied as a texture to the avatar's body mesh (e.g., a shirt, pants, tattoos).
+-   **FaceLayer**: The clothing is applied as a texture to the avatar's face mesh (e.g., makeup, face paint).
+-   **Accessory**: The clothing is a separate 3D model that is attached to the avatar's skeleton (e.g., a hat, glasses).

--- a/docs/Clothing/EClothingColor.md
+++ b/docs/Clothing/EClothingColor.md
@@ -1,0 +1,33 @@
+# EClothingColor
+
+An enum that defines a palette of available colors for clothing items.
+
+## Values
+
+-   `White`
+-   `LightGrey`
+-   `DarkGrey`
+-   `Charcoal`
+-   `Black`
+-   `LightRed`
+-   `Red`
+-   `Crimson`
+-   `Orange`
+-   `Tan`
+-   `Brown`
+-   `Coral`
+-   `Beige`
+-   `Yellow`
+-   `Lime`
+-   `LightGreen`
+-   `DarkGreen`
+-   `Cyan`
+-   `SkyBlue`
+-   `Blue`
+-   `DeepBlue`
+-   `Navy`
+-   `DeepPurple`
+-   `Purple`
+-   `Magenta`
+-   `BrightPink`
+-   `HotPink`

--- a/docs/Clothing/EClothingSlot.md
+++ b/docs/Clothing/EClothingSlot.md
@@ -1,0 +1,16 @@
+# EClothingSlot
+
+An enum that defines the available slots where clothing can be equipped on an avatar.
+
+## Values
+
+-   **Feet**: For shoes, boots, etc.
+-   **Bottom**: For pants, shorts, skirts, etc.
+-   **Waist**: For belts.
+-   **Top**: For shirts, t-shirts, etc.
+-   **Outerwear**: For jackets, coats, etc.
+-   **Hands**: For gloves.
+-   **Neck**: For necklaces, scarves, etc.
+-   **Eyes**: For glasses, goggles, etc.
+-   **Head**: For hats, helmets, etc.
+-   **Wrist**: For watches, bracelets, etc.

--- a/docs/Combat/CombatBehaviour.md
+++ b/docs/Combat/CombatBehaviour.md
@@ -1,0 +1,67 @@
+# CombatBehaviour
+
+Inherits from `ScheduleOne.NPCs.Behaviour.Behaviour`.
+
+## Description
+
+This is a comprehensive NPC behaviour class that manages all aspects of combat against a player target. It handles target acquisition, movement, weapon usage, line-of-sight checks, and searching for the target if they are lost.
+
+## Key Fields & Properties
+
+-   **TargetPlayer**: `Player` (read-only) - The player the NPC is currently engaged in combat with.
+-   **DefaultWeapon**: `AvatarWeapon` - The default weapon the NPC will equip when entering combat.
+-   **VirtualPunchWeapon**: `AvatarMeleeWeapon` - A "virtual" weapon used for unarmed attacks.
+-   **GiveUpRange**: `float` - The maximum distance the target can be before the NPC gives up and ends combat.
+-   **GiveUpTime**: `float` - The maximum time the NPC will search for a lost target before giving up.
+-   **IsSearching**: `bool` (read-only) - Is the NPC currently in a "search" state for a lost target?
+-   **timeSinceLastSighting**: `protected float` - A timer tracking how long it has been since the target was visible.
+-   **lastKnownTargetPosition**: `protected Vector3` - The last position where the target was seen.
+
+## Core Logic & State Machine
+
+The `CombatBehaviour` operates as a state machine driven by the visibility of the `TargetPlayer`.
+
+1.  **StartCombat**: When the behaviour begins, the NPC equips its `DefaultWeapon`, sets its emotional state to "Angry", and adjusts its movement parameters for combat.
+
+2.  **Target Visible (`isTargetRecentlyVisible` is true)**:
+    -   The NPC will try to maintain an optimal distance from the target based on its current weapon's `MinUseRange` and `MaxUseRange`.
+    -   It calls `RepositionToTargetRange` to move if it's too close or too far.
+    -   If it's within range and ready to attack, it calls `Attack()`.
+    -   The `lastKnownTargetPosition` is continuously updated.
+
+3.  **Target Lost (`isTargetRecentlyVisible` is false)**:
+    -   The NPC will move towards the `lastKnownTargetPosition`.
+    -   Once it reaches that position, if the target is still not visible, it calls `StartSearching()`.
+
+4.  **Searching**:
+    -   The NPC moves to random reachable points within an expanding radius around the `lastKnownTargetPosition`.
+    -   The search continues until the target is reacquired or the `GiveUpTime` is exceeded.
+
+5.  **EndCombat**: Combat ends if the target is invalid (dead, arrested), gets too far away (`GiveUpRange`), or is not found within the `GiveUpTime`. The NPC unequips its weapon and returns to a normal state.
+
+## Key Methods
+
+### SetTarget
+`public virtual void SetTarget(NetworkConnection conn, NetworkObject target)`
+
+An RPC to assign a `Player` as the combat target. This is the entry point for initiating combat.
+
+### BehaviourUpdate
+`public override void BehaviourUpdate()`
+
+The main update loop for the behaviour. It directs the NPC's actions based on the current state (target visible, target lost, searching).
+
+### Attack
+`protected virtual void Attack()`
+
+An RPC that triggers an attack with the `currentWeapon` or the `VirtualPunchWeapon` if unarmed.
+
+### CheckPlayerVisibility
+`protected void CheckPlayerVisibility()`
+
+Called every frame to update the visibility status of the target using the NPC's `VisionCone`. It manages the `isTargetRecentlyVisible` and `isTargetImmediatelyVisible` flags and the `timeSinceLastSighting` timer.
+
+### StartSearching / StopSearching
+`private void StartSearching()` and `private void StopSearching()`
+
+Methods to start and stop the search routine coroutine, which handles the logic for looking for a lost target.

--- a/docs/Combat/CombatManager.md
+++ b/docs/Combat/CombatManager.md
@@ -1,0 +1,40 @@
+# CombatManager
+
+Inherits from `NetworkSingleton<CombatManager>`.
+
+## Description
+
+A singleton manager responsible for handling combat-related events that need to be synchronized across the network, with a primary focus on creating explosions.
+
+## Fields
+
+-   **MeleeLayerMask**: `LayerMask` - A layer mask for melee combat calculations.
+-   **ExplosionLayerMask**: `LayerMask` - A layer mask used for determining the location of explosions.
+-   **RangedWeaponLayerMask**: `LayerMask` - A layer mask for ranged weapon calculations.
+-   **ExplosionPrefab**: `Explosion` - The prefab to instantiate when an explosion is created.
+
+## Methods
+
+### CreateTestExplosion
+`public void CreateTestExplosion()`
+
+A debug method callable from a button in the Inspector. It creates a test explosion 10 units in front of the player's camera, or at the point the camera is looking at if it hits something.
+
+### CreateExplosion
+`public void CreateExplosion(Vector3 origin, ExplosionData data)`
+
+The main public method for creating an explosion. It generates a random ID for the explosion and then calls a `ServerRpc` to initiate the explosion creation on the server, which then broadcasts it to all clients.
+
+-   **Parameters:**
+    -   `origin`: The world-space position where the explosion should occur.
+    -   `data`: An `ExplosionData` object containing the parameters for the explosion (e.g., radius, damage).
+
+### CreateExplosion (ServerRpc)
+`private void CreateExplosion(Vector3 origin, ExplosionData data, int id)`
+
+A `ServerRpc` that is called by clients. It simply calls the `Explosion` `ObserversRpc` to ensure the event is broadcast to all clients (including the server).
+
+### Explosion (ObserversRpc)
+`private void Explosion(Vector3 origin, ExplosionData data, int id)`
+
+An `ObserversRpc` that is called on all clients. It checks if the explosion `id` has already been processed to prevent duplicates, then instantiates the `ExplosionPrefab`, initializes it with the provided data, and schedules it for destruction after 3 seconds.

--- a/missing_docs.txt
+++ b/missing_docs.txt
@@ -5,27 +5,12 @@
 **Building:**
 
 **Calling:**
-- PayPhone.cs
 
 **Casino:**
-- BlackjackGameController.cs
-- PlayingCard.cs
-- RTBGameController.cs
-- SlotMachine.cs
-- SlotReel.cs
 
 **Clothing:**
-- ClothingColorExtensions.cs
-- ClothingDefinition.cs
-- ClothingInstance.cs
-- ClothingUtility.cs
-- EClothingApplicationType.cs
-- EClothingColor.cs
-- EClothingSlot.cs
 
 **Combat:**
-- CombatBehaviour.cs
-- CombatManager.cs
 - EImpactType.cs
 - Explosion.cs
 - ExplosionData.cs


### PR DESCRIPTION
This commit continues the process of adding extensive markdown documentation for the `ScheduleOne` namespace, following the guide provided in `missing_docs.txt`.

The following namespaces have now been fully documented:
- `Calling`
- `Casino`
- `Clothing`

Work has also progressed on the `Combat` namespace. All documented C# files have a corresponding `.md` file in the `docs/` directory, which mirrors the C# namespace structure.